### PR TITLE
Add UI atoms for APC40

### DIFF
--- a/public/styles/fader-control.css
+++ b/public/styles/fader-control.css
@@ -1,0 +1,20 @@
+@import url('./colors.css');
+
+.fader {
+  -webkit-appearance: none;
+  width: 8px;
+  height: 100px;
+  background: var(--color-border);
+  border-radius: 4px;
+  writing-mode: bt-lr;
+  transform: rotate(-90deg);
+}
+
+.fader::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 20px;
+  height: 12px;
+  background: var(--color-primary);
+  border-radius: 2px;
+  cursor: pointer;
+}

--- a/public/styles/knob-control.css
+++ b/public/styles/knob-control.css
@@ -1,0 +1,19 @@
+@import url('./colors.css');
+
+.knob {
+  -webkit-appearance: none;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+}
+
+.knob::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  cursor: pointer;
+}

--- a/public/styles/label-text.css
+++ b/public/styles/label-text.css
@@ -1,0 +1,7 @@
+@import url('./colors.css');
+
+.label {
+  font-family: 'JetBrains Mono', Inter, system-ui, sans-serif;
+  color: var(--color-text);
+  font-size: 12px;
+}

--- a/public/styles/led-indicator.css
+++ b/public/styles/led-indicator.css
@@ -1,0 +1,13 @@
+@import url('./colors.css');
+
+.led {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+}
+
+.led.on {
+  background: var(--color-primary);
+}

--- a/public/styles/pad-button.css
+++ b/public/styles/pad-button.css
@@ -1,0 +1,17 @@
+@import url('./colors.css');
+
+.pad {
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--color-border);
+  background: var(--color-button-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.pad.active {
+  background: var(--color-primary);
+}

--- a/src/components/atoms/FaderControl.ts
+++ b/src/components/atoms/FaderControl.ts
@@ -1,0 +1,40 @@
+export class FaderControl extends HTMLElement {
+  private input: HTMLInputElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    this.input = document.createElement('input');
+    this.input.type = 'range';
+    this.input.min = this.getAttribute('min') ?? '0';
+    this.input.max = this.getAttribute('max') ?? '127';
+    this.input.value = this.getAttribute('value') ?? this.input.min;
+    this.input.className = 'fader';
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/fader-control.css';
+    shadow.append(link, this.input);
+  }
+
+  static get observedAttributes() {
+    return ['min', 'max', 'value'];
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, value: string | null) {
+    if (name === 'min') {
+      this.input.min = value ?? '0';
+    } else if (name === 'max') {
+      this.input.max = value ?? '127';
+    } else if (name === 'value') {
+      this.input.value = value ?? this.input.min;
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'fader-control': FaderControl;
+  }
+}
+
+customElements.define('fader-control', FaderControl);

--- a/src/components/atoms/KnobControl.ts
+++ b/src/components/atoms/KnobControl.ts
@@ -1,0 +1,40 @@
+export class KnobControl extends HTMLElement {
+  private input: HTMLInputElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    this.input = document.createElement('input');
+    this.input.type = 'range';
+    this.input.min = this.getAttribute('min') ?? '0';
+    this.input.max = this.getAttribute('max') ?? '127';
+    this.input.value = this.getAttribute('value') ?? this.input.min;
+    this.input.className = 'knob';
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/knob-control.css';
+    shadow.append(link, this.input);
+  }
+
+  static get observedAttributes() {
+    return ['min', 'max', 'value'];
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, value: string | null) {
+    if (name === 'min') {
+      this.input.min = value ?? '0';
+    } else if (name === 'max') {
+      this.input.max = value ?? '127';
+    } else if (name === 'value') {
+      this.input.value = value ?? this.input.min;
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'knob-control': KnobControl;
+  }
+}
+
+customElements.define('knob-control', KnobControl);

--- a/src/components/atoms/LabelText.ts
+++ b/src/components/atoms/LabelText.ts
@@ -1,0 +1,33 @@
+export class LabelText extends HTMLElement {
+  private span: HTMLSpanElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    this.span = document.createElement('span');
+    this.span.className = 'label';
+    this.span.textContent = this.getAttribute('text') ?? '';
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/label-text.css';
+    shadow.append(link, this.span);
+  }
+
+  static get observedAttributes() {
+    return ['text'];
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, value: string | null) {
+    if (name === 'text') {
+      this.span.textContent = value ?? '';
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'label-text': LabelText;
+  }
+}
+
+customElements.define('label-text', LabelText);

--- a/src/components/atoms/LedIndicator.ts
+++ b/src/components/atoms/LedIndicator.ts
@@ -1,0 +1,39 @@
+export class LedIndicator extends HTMLElement {
+  private led: HTMLDivElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    this.led = document.createElement('div');
+    this.led.className = 'led';
+    if (this.hasAttribute('on')) {
+      this.led.classList.add('on');
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/led-indicator.css';
+    shadow.append(link, this.led);
+  }
+
+  static get observedAttributes() {
+    return ['on'];
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, value: string | null) {
+    if (name === 'on') {
+      if (value !== null) {
+        this.led.classList.add('on');
+      } else {
+        this.led.classList.remove('on');
+      }
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'led-indicator': LedIndicator;
+  }
+}
+
+customElements.define('led-indicator', LedIndicator);

--- a/src/components/atoms/PadButton.ts
+++ b/src/components/atoms/PadButton.ts
@@ -1,0 +1,42 @@
+export class PadButton extends HTMLElement {
+  private button: HTMLButtonElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    this.button = document.createElement('button');
+    this.button.className = 'pad';
+    this.button.textContent = this.getAttribute('label') ?? '';
+    if (this.hasAttribute('active')) {
+      this.button.classList.add('active');
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/pad-button.css';
+    shadow.append(link, this.button);
+  }
+
+  static get observedAttributes() {
+    return ['label', 'active'];
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, value: string | null) {
+    if (name === 'label') {
+      this.button.textContent = value ?? '';
+    } else if (name === 'active') {
+      if (value !== null) {
+        this.button.classList.add('active');
+      } else {
+        this.button.classList.remove('active');
+      }
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'pad-button': PadButton;
+  }
+}
+
+customElements.define('pad-button', PadButton);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,7 @@
 export * from './atoms/UiButton';
+export * from './atoms/PadButton';
+export * from './atoms/KnobControl';
+export * from './atoms/FaderControl';
+export * from './atoms/LedIndicator';
+export * from './atoms/LabelText';
 export * from './molecules/UiCard';


### PR DESCRIPTION
## Summary
- implement PadButton, KnobControl, FaderControl, LedIndicator and LabelText atoms
- export new atoms from `src/components/index.ts`
- add basic CSS styles for each atom

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_6859cf9608ac832f8058a3197b2418cd