### PR TITLE
Implement APC section organisms

### DIFF
--- a/public/styles/apc-clip-section.css
+++ b/public/styles/apc-clip-section.css
@@ -1,0 +1,7 @@
+@import url('./spacing.css');
+
+.clip-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}

--- a/public/styles/apc-master-section.css
+++ b/public/styles/apc-master-section.css
@@ -1,0 +1,7 @@
+@import url('./spacing.css');
+
+.master-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}

--- a/public/styles/apc-track-section.css
+++ b/public/styles/apc-track-section.css
@@ -1,0 +1,7 @@
+@import url('./spacing.css');
+
+.track-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,3 +9,6 @@ export * from './molecules/ClipGrid';
 export * from './molecules/KnobBank';
 export * from './molecules/FaderBank';
 export * from './molecules/TransportControls';
+export * from './organisms/APCTrackSection';
+export * from './organisms/APCMasterSection';
+export * from './organisms/APCClipSection';

--- a/src/components/organisms/APCClipSection.ts
+++ b/src/components/organisms/APCClipSection.ts
@@ -1,0 +1,24 @@
+export class APCClipSection extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    const section = document.createElement('div');
+    section.className = 'clip-section';
+
+    const grid = document.createElement('clip-grid');
+    section.append(grid);
+
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/apc-clip-section.css';
+    shadow.append(link, section);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'apc-clip-section': APCClipSection;
+  }
+}
+
+customElements.define('apc-clip-section', APCClipSection);

--- a/src/components/organisms/APCMasterSection.ts
+++ b/src/components/organisms/APCMasterSection.ts
@@ -1,0 +1,24 @@
+export class APCMasterSection extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    const section = document.createElement('div');
+    section.className = 'master-section';
+
+    const transport = document.createElement('transport-controls');
+    section.append(transport);
+
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/apc-master-section.css';
+    shadow.append(link, section);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'apc-master-section': APCMasterSection;
+  }
+}
+
+customElements.define('apc-master-section', APCMasterSection);

--- a/src/components/organisms/APCTrackSection.ts
+++ b/src/components/organisms/APCTrackSection.ts
@@ -1,0 +1,25 @@
+export class APCTrackSection extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    const section = document.createElement('div');
+    section.className = 'track-section';
+
+    const knobs = document.createElement('knob-bank');
+    const faders = document.createElement('fader-bank');
+    section.append(knobs, faders);
+
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/apc-track-section.css';
+    shadow.append(link, section);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'apc-track-section': APCTrackSection;
+  }
+}
+
+customElements.define('apc-track-section', APCTrackSection);


### PR DESCRIPTION
## Summary
- add APCTrackSection, APCMasterSection and APCClipSection web components
- add simple layout styles for new organisms
- export new organisms from components index

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6859d300c3f0832f863c1c1e6bc1f98e