### PR TITLE
Add APC40 template

### DIFF
--- a/public/apc40.html
+++ b/public/apc40.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>APC40 UI</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <apc40-template></apc40-template>
+  <script type="module" src="/src/main.ts"></script>
+</body>
+</html>

--- a/public/styles/apc40-template.css
+++ b/public/styles/apc40-template.css
@@ -1,0 +1,23 @@
+@import url('./spacing.css');
+
+.apc40 {
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  grid-template-rows: auto 1fr;
+  grid-template-areas:
+    'track master'
+    'clip master';
+  gap: var(--spacing-lg);
+}
+
+apc-track-section {
+  grid-area: track;
+}
+
+apc-clip-section {
+  grid-area: clip;
+}
+
+apc-master-section {
+  grid-area: master;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,3 +12,4 @@ export * from './molecules/TransportControls';
 export * from './organisms/APCTrackSection';
 export * from './organisms/APCMasterSection';
 export * from './organisms/APCClipSection';
+export * from './templates/APC40Template';

--- a/src/components/templates/APC40Template.ts
+++ b/src/components/templates/APC40Template.ts
@@ -1,0 +1,28 @@
+export class APC40Template extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'apc40';
+
+    const track = document.createElement('apc-track-section');
+    const clip = document.createElement('apc-clip-section');
+    const master = document.createElement('apc-master-section');
+
+    wrapper.append(track, clip, master);
+
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/styles/apc40-template.css';
+    shadow.append(link, wrapper);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'apc40-template': APC40Template;
+  }
+}
+
+customElements.define('apc40-template', APC40Template);


### PR DESCRIPTION
## Summary
- add APC40Template web component
- add layout styles for APC40Template
- export template in component index
- create a demo page `public/apc40.html`

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_b_6859d423ddc4832faaf294e7262fded1