### PR TITLE
Add client-side router for APC40 page

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,15 @@
   <h1>DMX</h1>
 </header>
 <main id="app">
-  <ui-card title="Akai APC40">
-    <p>Vista de la interfaz</p>
-    <ui-button label="Ir"></ui-button>
-  </ui-card>
+  <div id="home">
+    <ui-card title="Akai APC40">
+      <p>Vista de la interfaz</p>
+      <ui-button id="apc40-link" label="Ir"></ui-button>
+    </ui-card>
+  </div>
+  <div id="apc40-view" hidden>
+    <apc40-template></apc40-template>
+  </div>
 </main>
 <footer class="technologies">
   <span>Footer</span>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,1 +1,22 @@
 import './components';
+import { Router } from './router';
+
+const home = document.getElementById('home');
+const apc40View = document.getElementById('apc40-view');
+const goButton = document.getElementById('apc40-link');
+
+const router = new Router();
+
+router.register('/', () => {
+  home?.removeAttribute('hidden');
+  apc40View?.setAttribute('hidden', '');
+});
+
+router.register('/apc40', () => {
+  apc40View?.removeAttribute('hidden');
+  home?.setAttribute('hidden', '');
+});
+
+goButton?.addEventListener('click', () => router.navigate('/apc40'));
+
+router.start();

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,26 @@
+export type RouteCallback = () => void;
+
+export class Router {
+  private routes = new Map<string, RouteCallback>();
+
+  register(path: string, callback: RouteCallback) {
+    this.routes.set(path, callback);
+  }
+
+  navigate(path: string) {
+    history.pushState({}, '', path);
+    this.handle(path);
+  }
+
+  start() {
+    window.addEventListener('popstate', () => this.handle(location.pathname));
+    this.handle(location.pathname);
+  }
+
+  private handle(path: string) {
+    const cb = this.routes.get(path);
+    if (cb) {
+      cb();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create a simple SPA router
- update `index.html` structure to support views
- wire button to navigate to `/apc40`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6859e2744f9c832fa3df19f590a51439