### PR TITLE
Implement neon Akai APC40 layout

### DIFF
--- a/public/styles/apc-clip-section.css
+++ b/public/styles/apc-clip-section.css
@@ -10,4 +10,15 @@
   border: 1px solid var(--color-border);
   border-radius: 8px;
   box-shadow: var(--glow-accent-1);
+  position: relative;
+}
+
+.clip-section::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--gradient-neon);
 }

--- a/public/styles/apc-master-section.css
+++ b/public/styles/apc-master-section.css
@@ -10,4 +10,15 @@
   border: 1px solid var(--color-border);
   border-radius: 8px;
   box-shadow: var(--glow-accent-2);
+  position: relative;
+}
+
+.master-section::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--gradient-neon);
 }

--- a/public/styles/apc-track-section.css
+++ b/public/styles/apc-track-section.css
@@ -10,4 +10,15 @@
   border: 1px solid var(--color-border);
   border-radius: 8px;
   box-shadow: var(--glow-primary);
+  position: relative;
+}
+
+.track-section::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--gradient-neon);
 }

--- a/public/styles/clip-grid.css
+++ b/public/styles/clip-grid.css
@@ -2,6 +2,8 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(8, 1fr);
+  grid-template-columns: repeat(8, var(--size-pad));
+  grid-template-rows: repeat(5, var(--size-pad));
   gap: var(--spacing-xs);
+  justify-content: center;
 }

--- a/public/styles/colors.css
+++ b/public/styles/colors.css
@@ -24,4 +24,17 @@
   --glow-accent-1: 0 0 10px var(--color-accent-1), 0 0 20px rgba(255, 0, 255, 0.3);
   --glow-accent-2: 0 0 10px var(--color-accent-2), 0 0 20px rgba(0, 255, 0, 0.3);
   --glow-accent-3: 0 0 10px var(--color-accent-3), 0 0 20px rgba(255, 51, 0, 0.3);
+
+  /* Component colors */
+  --color-pad-bg: #1b1b2d;
+  --color-knob-bg: #141424;
+
+  /* Shared gradients */
+  --gradient-neon: linear-gradient(
+    90deg,
+    var(--color-primary),
+    var(--color-accent-1),
+    var(--color-accent-2),
+    var(--color-accent-3)
+  );
 }

--- a/public/styles/fader-control.css
+++ b/public/styles/fader-control.css
@@ -3,7 +3,7 @@
 .fader {
   -webkit-appearance: none;
   width: 8px;
-  height: 100px;
+  height: var(--size-fader-length);
   background: linear-gradient(to bottom, var(--color-border), var(--color-background));
   border-radius: 4px;
   writing-mode: bt-lr;

--- a/public/styles/knob-control.css
+++ b/public/styles/knob-control.css
@@ -2,10 +2,10 @@
 
 .knob {
   -webkit-appearance: none;
-  width: 40px;
-  height: 40px;
+  width: var(--size-knob);
+  height: var(--size-knob);
   border-radius: 50%;
-  background: var(--color-surface);
+  background: var(--color-knob-bg);
   border: 1px solid var(--color-border);
   position: relative;
   transition: all 0.2s ease;
@@ -14,7 +14,7 @@
 
 .knob:hover {
   border-color: var(--color-primary);
-  box-shadow: 0 0 8px var(--color-primary-glow), inset 0 0 5px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--glow-primary), inset 0 0 5px rgba(0, 0, 0, 0.5);
 }
 
 .knob:focus {

--- a/public/styles/pad-button.css
+++ b/public/styles/pad-button.css
@@ -1,10 +1,10 @@
 @import url('./colors.css');
 
 .pad {
-  width: 40px;
-  height: 40px;
+  width: var(--size-pad);
+  height: var(--size-pad);
   border: 1px solid var(--color-border);
-  background: var(--color-button-bg);
+  background: var(--color-pad-bg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -17,7 +17,7 @@
 
 .pad:hover {
   border-color: var(--color-primary);
-  box-shadow: 0 0 5px var(--color-primary-glow);
+  box-shadow: var(--glow-accent-1);
 }
 
 .pad.active {

--- a/public/styles/spacing.css
+++ b/public/styles/spacing.css
@@ -4,4 +4,9 @@
   --spacing-md: 16px;
   --spacing-lg: 24px;
   --spacing-xl: 40px;
+
+  /* Control sizes */
+  --size-knob: 40px;
+  --size-pad: 40px;
+  --size-fader-length: 100px;
 }


### PR DESCRIPTION
## Summary
- add color and size variables for APC40 controls
- define a multicolor gradient and apply to sections
- tweak pad and knob styles to use variables
- size the clip grid and fader length with tokens

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6862fc885098832fbc22f5093aee0233